### PR TITLE
Upgrade Vite to version 7.1.5

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,7 @@
     "ts-jest": "^29.3.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.26.1",
-    "vite": "^7.1.4",
+    "vite": "^7.1.5",
     "vitest": "^3.1.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "ts-jest": "^29.3.2",
                 "typescript": "^5.9.2",
                 "typescript-eslint": "^8.26.1",
-                "vite": "^7.1.4",
+                "vite": "^7.1.5",
                 "vitest": "^3.1.1"
             }
         },
@@ -85,10 +85,27 @@
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
             }
         },
+        "client/node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
         "client/node_modules/vite": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
-            "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+            "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -97,7 +114,7 @@
                 "picomatch": "^4.0.3",
                 "postcss": "^8.5.6",
                 "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.14"
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"


### PR DESCRIPTION
## Summary
• Upgrades Vite from version 7.1.4 to 7.1.5
• Updates client package.json and package-lock.json

## Test plan
- [x] Verify dev server starts correctly with `npm run dev`
- [x] Verify build process works with `npm run build`
- [x] Test client functionality to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)