### PR TITLE
Upgrade Playwright to version 1.56.1

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,25 +4,25 @@
     "description": "End-to-end tests for InnieMe application",
     "private": true,
     "scripts": {
-      "test": "playwright test",
-      "test:headed": "playwright test --headed",
-      "test:chrome": "playwright test --project=chromium",
-      "test:firefox": "playwright test --project=firefox",
-      "test:webkit": "playwright test --project=webkit",
-      "test:auth": "AUTH_TOKEN=true playwright test",
-      "install:browsers": "playwright install",
-      "report": "playwright show-report",
-      "debug": "playwright test --debug"
+        "test": "playwright test",
+        "test:headed": "playwright test --headed",
+        "test:chrome": "playwright test --project=chromium",
+        "test:firefox": "playwright test --project=firefox",
+        "test:webkit": "playwright test --project=webkit",
+        "test:auth": "AUTH_TOKEN=true playwright test",
+        "install:browsers": "playwright install",
+        "report": "playwright show-report",
+        "debug": "playwright test --debug"
     },
     "dependencies": {
-      "@playwright/test": "^1.55.0",
-      "typescript": "^5.9.2"
+        "@playwright/test": "^1.56.1",
+        "typescript": "^5.9.2"
     },
     "devDependencies": {
-      "@types/node": "^24.3.0",
-      "ts-node": "^10.9.2"
+        "@types/node": "^24.3.0",
+        "ts-node": "^10.9.2"
     },
     "engines": {
-      "node": ">=16.0.0"
+        "node": ">=16.0.0"
     }
-  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,7 +181,7 @@
         "e2e": {
             "version": "1.0.0",
             "dependencies": {
-                "@playwright/test": "^1.55.0",
+                "@playwright/test": "^1.56.1",
                 "typescript": "^5.9.2"
             },
             "devDependencies": {
@@ -3615,12 +3615,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.55.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
-            "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+            "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.55.0"
+                "playwright": "1.56.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -12630,12 +12630,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.55.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
-            "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.55.0"
+                "playwright-core": "1.56.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -12648,9 +12648,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.55.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
-            "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+            "version": "1.56.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+            "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"


### PR DESCRIPTION
## Summary
- Upgrade Playwright from version 1.55.0 to 1.56.1
- Install latest browser binaries (Chromium 141.0, Firefox 142.0, Webkit 26.0)

## New Features Available
- **Agent Support**: New `npx playwright init-agents` command with support for VS Code, Claude Code, and other agentic tools
- **Enhanced Debugging**: New methods `page.consoleMessages()`, `page.pageErrors()`, and `page.requests()` for improved debugging
- **IndexedDB Support**: Save and restore IndexedDB contents in `browserContext.storageState()` (useful for Firebase Auth)
- **Improved Reporting**: Copy prompt button in HTML reporter and trace viewer

## Changes
- `@playwright/test`: ^1.55.0 → ^1.56.1
- `playwright`: 1.55.0 → 1.56.1
- `playwright-core`: 1.55.0 → 1.56.1

## Test Plan
- [ ] Run e2e tests: `npm run test:e2e`
- [ ] Verify all browser tests pass (Chrome, Firefox, Webkit)
- [ ] Verify no breaking changes in test functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)