### PR TITLE
Upgrade Vite to version 7.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
             "devDependencies": {
                 "@vitejs/plugin-react": "^4.4.1",
                 "concurrently": "^8.2.0",
-                "vite": "^6.4.1"
+                "vite": "^7.1.11"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -14630,24 +14630,24 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "version": "7.1.12",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
+            "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -14656,14 +14656,14 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@types/node": "^20.19.0 || >=22.12.0",
                 "jiti": ">=1.21.0",
-                "less": "*",
+                "less": "^4.0.0",
                 "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "devDependencies": {
         "@vitejs/plugin-react": "^4.4.1",
         "concurrently": "^8.2.0",
-        "vite": "^6.4.1"
+        "vite": "^7.1.11"
     },
     "overrides": {
         "glob": "^10.0.0",


### PR DESCRIPTION
## Summary
- Upgrade Vite from 6.4.1 to 7.1.11 in root package.json
- Aligns root package with client package which already uses Vite 7.1.11
- Updates package-lock.json with new dependencies

## Test plan
- [x] Verify the build completes successfully: `npm run build`
- [x] Verify the development server starts: `npm start`
- [x] Verify client tests pass: `npm run test:client`
- [x] Verify no runtime errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)