### PR TITLE
Fix npm install in debug Dockerfile with legacy-peer-deps flag

### DIFF
--- a/server/Dockerfile.debug
+++ b/server/Dockerfile.debug
@@ -4,7 +4,7 @@ FROM node:20
 WORKDIR /app
 RUN mkdir -p /app/config
 COPY package*.json ./
-RUN npm install
+RUN npm install --legacy-peer-deps
 COPY . .
 EXPOSE 3000
 # Expose debugging port


### PR DESCRIPTION
## Summary
- Adds `--legacy-peer-deps` flag to `npm install` command in [server/Dockerfile.debug](server/Dockerfile.debug#L7)
- Resolves peer dependency conflicts during Docker image build

## Problem
The debug Dockerfile was failing during `npm install` due to peer dependency conflicts between packages.

## Solution
Added the `--legacy-peer-deps` flag to bypass strict peer dependency resolution, allowing the build to complete successfully while maintaining backward compatibility.

## Test plan
- [x] Build the debug Docker image using `npm run docker:build:debug`
- [x] Verify the image builds successfully without npm install errors
- [x] Start the debug container using `npm run docker:up:debug`
- [x] Verify the server starts correctly and all dependencies are properly installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)