### PR TITLE
Add restart policy to debug docker-compose services

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile.debug
+    restart: always
     ports:
       - "3000:3000"
     depends_on:
@@ -12,6 +13,7 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile.debug
+    restart: always
     ports:
       - "3001:3001"
       - "9229:9229"


### PR DESCRIPTION
## Summary
- Add `restart: always` to client service in debug docker-compose
- Add `restart: always` to server service in debug docker-compose

This ensures containers automatically restart if they crash or when Docker restarts.